### PR TITLE
Fix some issues with deactivating the plugin with Meteor

### DIFF
--- a/plugin/helper.js
+++ b/plugin/helper.js
@@ -6,6 +6,14 @@ export default function(path) {
     transformRelativeToRootPath(path, rootPathSuffix) {
       if (this.hasRoot(path)) {
         const withoutRoot = path.substring(1, path.length);
+
+        // Here's we detect the use of Meteor that interferes with path resolution
+        // global.meteorBabelHelpers is something we can see when
+        // running inside Meteor.
+        if (global.meteorBabelHelpers && path.startsWith(this.root)) {
+          return path;
+        }
+
         return `${this.root}${rootPathSuffix ? rootPathSuffix : ''}/${withoutRoot}`;
       }
       if (typeof path === 'string') {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -22,15 +22,5 @@ export default function({ types: t }) {
     }
   }
 
-  // Here's we detect the use of Meteor and send a dummy plugin.
-  // That's because, Meteor already do this for us.
-  //  global.meteorBabelHelpers is something we can see when
-  //  running inside Meteor.
-  if (global.meteorBabelHelpers) {
-    return {
-      visitor: {}
-    };
-  }
-
   return new BabelRootImport();
 }


### PR DESCRIPTION
The patch 1.1.0 deactivates the plugin when Meteor is running. In some context (for instance with webpack:webpack), the plugin is still needed so we have to do a more subtle fix.
